### PR TITLE
Add more rail-specific text in hydrated readme

### DIFF
--- a/python-project-template/README.md.jinja
+++ b/python-project-template/README.md.jinja
@@ -1,12 +1,35 @@
 # {{project_name}}
 
 [![Template](https://img.shields.io/badge/Template-LINCC%20Frameworks%20Python%20Project%20Template-brightgreen)](https://lincc-ppt.readthedocs.io/en/latest/)
+[![codecov](https://codecov.io/gh/LSSTDESC/{{project_name}}/branch/main/graph/badge.svg)](https://codecov.io/gh/LSSTDESC/{{project_name}})
+[![PyPI](https://img.shields.io/pypi/v/{{package_name}}?color=blue&logo=pypi&logoColor=white)](https://pypi.org/project/{{package_name}}/)
 
-This project was automatically generated using the LINCC-Frameworks 
-[python-project-template](https://github.com/lincc-frameworks/python-project-template).
+TODO - add more about your project here.
 
-A repository badge was added to show that this project uses the python-project-template, however it's up to
-you whether or not you'd like to display it!
+## RAIL: Redshift Assessment Infrastructure Layers
 
-For more information about the project template see the 
-[documentation](https://lincc-ppt.readthedocs.io/en/latest/).
+This package is part of the larger ecosystem of Photometric Redshifts
+in [RAIL](https://github.com/LSSTDESC/RAIL).
+
+### Citing RAIL
+
+This code, while public on GitHub, has not yet been released by DESC and is
+still under active development. Our release of v1.0 will be accompanied by a
+journal paper describing the development and validation of RAIL.
+
+If you make use of the ideas or software in RAIL, please cite the repository 
+<https://github.com/LSSTDESC/RAIL>. You are welcome to re-use the code, which
+is open source and available under terms consistent with the MIT license.
+
+External contributors and DESC members wishing to use RAIL for non-DESC projects
+should consult with the Photometric Redshifts (PZ) Working Group conveners,
+ideally before the work has started, but definitely before any publication or 
+posting of the work to the arXiv.
+
+### Citing this package
+
+If you use this package, you should also cite the appropriate papers for each
+code used.  A list of such codes is included in the 
+[Citing RAIL](https://lsstdescrail.readthedocs.io/en/stable/source/citing.html)
+section of the main RAIL Read The Docs page.
+


### PR DESCRIPTION
This also adds some pointers back to RAIL and tips on citing RAIL and its ancillary packages.

Most other portions will be up to the maintainers to fill in.