### PR TITLE
Allow pylint to failure to pass CI checks

### DIFF
--- a/python-project-template/.github/workflows/linting.yml
+++ b/python-project-template/.github/workflows/linting.yml
@@ -32,3 +32,5 @@ jobs:
     - name: Analyze code with linter
       run: |
         pylint -rn -sn --recursive=y ./src
+      # the following line allows the CI test to pass, even if pylint fails
+      continue-on-error: true


### PR DESCRIPTION
Since most RAIL projects are being copied over from existing code, and because the code hasn't kept up with pylint styling, we want to allow users to "pass" the CI checks for pylint, even if pylint finds problems. 

Presumably, the maintainers of the various projects will go back at some point, fix all the pylint problems, and then remove the `continue-on-error` command in the CI test. 