### PR TITLE
Update supported python versions and clean up pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
         copier_config:
           - name: Base example
             package_name: example_package # The default package_name

--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ These instructions explain how to create a Personal Access Token: https://github
 
 Once your token is created save it as a **repository secret** with the name: ``ADD_TO_PROJECT_PAT``.
 
+### Utilize pre-commit hooks
+
+Pre-commit runs various tests against your code.
+These checks are mostly the same as those that are run in continuous integration,
+but by running them locally it's possible to reduce the amount of time between committing
+and finding errors in the code.
+
+It is not required to use pre-commit if you use this template, but it is available
+if you would like. To enable it, simply run ``pre-commit install``.
+
 ## Contributing to the Template
 
 ### WARNING:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "RAIL-project-template"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 readme = "README.md"
 authors = [

--- a/python-project-template/.github/workflows/linting.yml
+++ b/python-project-template/.github/workflows/linting.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/python-project-template/.github/workflows/smoke-test.yml
+++ b/python-project-template/.github/workflows/smoke-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
+++ b/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/python-project-template/.pre-commit-config.yaml
+++ b/python-project-template/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+fail_fast: true
 repos:
 
     # Clear output from jupyter notebooks so that only the input cells are committed.

--- a/python-project-template/.pre-commit-config.yaml
+++ b/python-project-template/.pre-commit-config.yaml
@@ -1,16 +1,5 @@
 repos:
 
-    # Compare the local template version to the latest remote template version
-    # This hook should always pass. It will print a message if the local version 
-    # is out of date.
-  - repo: https://github.com/lincc-frameworks/pre-commit-hooks
-    rev: v0.1
-    hooks:
-      - id: check-lincc-frameworks-template-version
-        name: Check template version
-        description: Compare current template version against latest
-        verbose: true
-
     # Clear output from jupyter notebooks so that only the input cells are committed.
   - repo: local
     hooks:
@@ -21,21 +10,6 @@ repos:
         stages: [commit]
         language: system
         entry: jupyter nbconvert --clear-output
-
-    # Run unit tests, verify that they pass. Note that coverage is run against
-    # the ./src directory here because that is what will be committed. In the 
-    # github workflow script, the coverage is run against the installed package
-    # and uploaded to Codecov by calling pytest like so:
-    # `python -m pytest --cov=<package_name> --cov-report=xml`
-  - repo: local
-    hooks:
-      - id: pytest-check
-        name: Run unit tests
-        description: Run unit tests with pytest.
-        entry: bash -c "if python -m pytest --co -qq; then python -m pytest --cov=./src --cov-report=html; fi"
-        language: system
-        pass_filenames: false
-        always_run: true
 
     # prevents committing directly branches named 'main' and 'master'.
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -84,3 +58,18 @@ repos:
             "-rn", # Only display messages
             "-sn", # Don't display the score
           ]
+
+    # Run unit tests, verify that they pass. Note that coverage is run against
+    # the ./src directory here because that is what will be committed. In the 
+    # github workflow script, the coverage is run against the installed package
+    # and uploaded to Codecov by calling pytest like so:
+    # `python -m pytest --cov=<package_name> --cov-report=xml`
+  - repo: local
+    hooks:
+      - id: pytest-check
+        name: Run unit tests
+        description: Run unit tests with pytest.
+        entry: bash -c "if python -m pytest --co -qq; then python -m pytest --cov=./src --cov-report=html; fi"
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -1,5 +1,6 @@
 [project]
 name = "{{project_name}}"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 readme = "README.md"
 authors = [


### PR DESCRIPTION
**Updates supported python version in workflows.** 
Changes the requested python versions in all the relevant CI workflows from 3.8-3.10 to 3.9-3.11

**Specify minimum python in pyproject.toml**
States the minimum required version of python >3.9 in both pyproject.toml files. The one for this template, and the one that is used when hydrating a new project. 

**Clean up pre-commit.yml**
Removes the unnecessary check for updates that have occurred in the LINCC Frameworks PPT. Moves the pytest check to the last step (since that usually takes longer) and it's usually other hooks that fail (i.e.  pylint)
