### PR TITLE
Updating publish-to-pypi and README to use trusted publishing method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,11 @@ Go here: https://github.com/apps/codecov and configure it for your repository
 ### Publish to PyPI automatically
 
 A GitHub action has been created that will automatically publish a package to PyPI.
-To make use of that, you'll need to create an API key and save it your new repo.
-Follow these instructions to get started: https://lincc-ppt.readthedocs.io/en/latest/practices/pypi.html#set-up
+To make use of that, you'll use "trusted publishing". For a high level overview of
+trusted publishing see the PyPI documentation here: https://docs.pypi.org/trusted-publishers/
+
+For specific instructions to set up trusted publishing between GitHub and PyPI,
+take a look at the PyPI documentation here: https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/
 
 ### Automatically Add issues to the Project Tracker
 

--- a/python-project-template/.github/workflows/publish-to-pypi.yml
+++ b/python-project-template/.github/workflows/publish-to-pypi.yml
@@ -1,5 +1,5 @@
 # This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+# For more information see: https://github.com/pypa/gh-action-pypi-publish#trusted-publishing
 
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by
@@ -19,7 +19,8 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -33,7 +34,4 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Updated the github workflow that publishes to PyPI to use the trusted publishing method. Added instructions and references to the README documentation.