### PR TITLE
Update workflow to automatically add PRs to the project tracker.

### DIFF
--- a/python-project-template/.github/workflows/add-issue-to-project-tracker.yml
+++ b/python-project-template/.github/workflows/add-issue-to-project-tracker.yml
@@ -4,6 +4,8 @@ on:
   issues:
     types:
       - opened
+  pull_request:
+    types: [opened, reopened]
 
 jobs:
   add-to-project:


### PR DESCRIPTION
The change to the github workflow definition should now automatically add new and reopened PRs to the main RAIL project tracker. 

Users of the template will still need to create a personal access token with `project` level access, as described here: https://github.com/actions/add-to-project/releases#creating-a-pat-and-adding-it-to-your-repository

