### PR TITLE
Updated workflows to reduce python versions and enable manual trigger

### DIFF
--- a/python-project-template/.github/workflows/linting.yml
+++ b/python-project-template/.github/workflows/linting.yml
@@ -12,16 +12,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.9', '3.10', '3.11']
-
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -32,5 +28,6 @@ jobs:
     - name: Analyze code with linter
       run: |
         pylint -rn -sn --recursive=y ./src
+        pylint -rn -sn --recursive=y ./tests
       # the following line allows the CI test to pass, even if pylint fails
       continue-on-error: true

--- a/python-project-template/.github/workflows/smoke-test.yml
+++ b/python-project-template/.github/workflows/smoke-test.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: 45 6 * * *
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   build:
 


### PR DESCRIPTION
See #40 for details.

This PR updates two of the default workflows. Enables manual triggering of the daily smoke test. Additionally it reduces the number of python versions that the linter runs with. 