### PR TITLE
Removing problematic section of pyproject.toml, tool.setuptools.packages.find

### DIFF
--- a/python-project-template/pyproject.toml.jinja
+++ b/python-project-template/pyproject.toml.jinja
@@ -37,11 +37,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "src/rail/{{package_name}}/_version.py"
 
-[tool.setuptools.packages.find]
-where = ["src"]
-include = ["rail"]
-namespaces = true
-
 [tool.pytest.ini_options]
 testpaths = [
     "tests",


### PR DESCRIPTION
This section of the pyproject.toml file seems to cause a lot of issues and doesn't appear to be required to define a package as being a namespace package. It seems like python just figures it out without this specification. 