### PR TITLE
Update testing-and-coverage.yml.jinja to use codecov token

### DIFF
--- a/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
+++ b/python-project-template/.github/workflows/testing-and-coverage.yml.jinja
@@ -34,4 +34,6 @@ jobs:
       run: |
         python -m pytest tests --cov={{package_name}} --cov-report=xml
     - name: Upload coverage report to codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
+      with:
+        token: {% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}


### PR DESCRIPTION
The preferred method for uploading coverage reports to codecov has changed, and they expect a token to be included in the request. This PR updates the github action to match the current best practice.